### PR TITLE
chore: improve Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ COPY . .
 RUN chmod +x ./gradlew
 RUN ./gradlew --no-daemon shadowJar
 
+FROM openjdk:17-oracle
+
+RUN mkdir /app
+COPY --from=Build build/libs/citation.jar /app/citation.jar
+COPY --from=Build .env.example /app/.env
+
+WORKDIR /app
 LABEL org.opencontainers.image.source=https://github.com/m2en/citation
 
-CMD ["java", "-jar", "build/libs/citation.jar"]
+CMD ["java", "-jar", "/app/citation.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN chmod +x ./gradlew
 RUN ./gradlew --no-daemon shadowJar
 
-FROM openjdk:17-oracle
+FROM openjdk:17-oracle as Run
 
 RUN mkdir /app
 COPY --from=Build build/libs/citation.jar /app/citation.jar


### PR DESCRIPTION
マルチステージビルドを使用してイメージサイズを縮小 ( 1.22GB -> 488MB )