### PR TITLE
fix: Botのメッセージは無視するように

### DIFF
--- a/src/main/kotlin/dev/m2en/citation/message/QuoteSend.kt
+++ b/src/main/kotlin/dev/m2en/citation/message/QuoteSend.kt
@@ -156,10 +156,7 @@ object QuoteSendListener : MessageHandler {
             }
 
             if(message.editedTimestamp !== null) {
-                field {
-                    name = "編集"
-                    value = message.editedTimestamp.toString()
-                }
+                timestamp = message.editedTimestamp
             }
 
             if(messageAuthor.avatar !== null) {

--- a/src/main/kotlin/dev/m2en/citation/message/QuoteSend.kt
+++ b/src/main/kotlin/dev/m2en/citation/message/QuoteSend.kt
@@ -1,153 +1,203 @@
 package dev.m2en.citation.message
 
-import dev.kord.common.Color
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.MessageType
 import dev.kord.common.entity.Snowflake
-import dev.kord.core.behavior.getChannelOf
 import dev.kord.core.behavior.getChannelOfOrNull
 import dev.kord.core.behavior.reply
-import dev.kord.core.entity.Icon
-import dev.kord.core.entity.Message
-import dev.kord.core.entity.ReactionEmoji
-import dev.kord.core.entity.User
+import dev.kord.core.entity.*
 import dev.kord.core.entity.channel.*
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import dev.kord.rest.builder.message.EmbedBuilder
 import dev.m2en.citation.handler.MessageHandler
 import dev.m2en.citation.utils.Logger
+import dev.m2en.citation.utils.Utils
 
 object QuoteSendListener : MessageHandler {
     override suspend fun canProcess(message: Message): Boolean = message.author?.isBot == false
 
     override suspend fun messageHandle(message: Message) {
-        // GuildId/ChannelId/MessageId
+        val requester = message.author?.fetchMember(message.getGuild().id) ?: throw Error("リクエスト送信者を見つけることができませんでした。")
+
+        /**
+         * メッセージリンクを取り出す正規表現
+         * GuildId/ChannelId/MessageId
+         */
         val linkRegex = Regex("""https://(?:ptb\.|canary\.)?discord(?:app)?.com/channels/(\d+)/(\d+)/(\d+)""")
-        // <...GuildId/ChannelId/MessageId>
-        val skipRegex = Regex("""<.*?>""")
 
-        var str = message.content
-        str = str.replace(skipRegex, "")
-        if(!(linkRegex.containsMatchIn(str))) {
+        /**
+         * スキップ対象のメッセージリンクを取り出す正規表現
+         * e.x) <https://discord.com/channels/1025777155604496515/1025777155604496515/1025777155604496515>
+         */
+        val skipLinkRegex = Regex("""<.*?>""")
+
+        var content = message.content
+        content = content.replace(skipLinkRegex, "")
+        if(!(linkRegex.containsMatchIn(content))) {
             return
         }
 
-        val matches = linkRegex.find(str) ?: return
-        if(Snowflake(matches.groupValues[1]) != message.getGuild().id) {
-            Logger.sendKWarn("${message.author?.tag} の引用をスキップしました: ギルドが一致しません。")
-            return
-        }
+        val quoteMessage = getQuoteMessage(message, linkRegex, requester)
 
-        val targetChannel = message.getGuild().getChannelOfOrNull<GuildMessageChannel>(Snowflake(matches.groupValues[2]))
-        val messageChannelData = message.getGuild().getChannelOf<GuildMessageChannel>(message.channelId)
-        if(targetChannel == null) {
-            Logger.sendError("${message.author?.tag} の引用に失敗しました: チャンネルが見つかりません。")
-            return
-        }
-        if(isChannelNsfw(targetChannel, messageChannelData)) {
-            Logger.sendError("${message.author?.tag} の引用に失敗しました: NSFWとして指定されているチャンネルのメッセージです。")
-            return
-        }
-
-        val targetMessage = targetChannel.getMessageOrNull(Snowflake(matches.groupValues[3]))
-        if(targetMessage == null) {
-            Logger.sendError("${message.author?.tag} の引用に失敗しました: メッセージが見つかりません。")
-            return
-        }
-        if(!(checkMessageType(targetMessage))) {
-            Logger.sendKWarn("通常メッセージではないため、引用をキャンセルしました。: ${targetMessage.type}")
-            return
-        }
-
-        if(targetMessage.embeds.isNotEmpty() && targetMessage.content.isEmpty()) {
-            Logger.sendKWarn("メッセージ内容が空で、Embedのみだったため引用をキャンセルしました。")
-            return
-        }
-
-        val targetUser = targetMessage.author
-        val targetUserName = if(targetMessage.author == null) {
-            "不明"
-        } else {
-            targetMessage.author!!.username
-        }
-
-
-        val replyMessage = message.reply { embeds.add(buildEmbed(targetMessage, targetUserName, targetUser?.avatar, message.author)) }
+        val replyMessage = message.reply { embeds.add(buildEmbed(quoteMessage, requester.username)) }
         replyMessage.addReaction(ReactionEmoji.Unicode("\uD83D\uDDD1"))
-        Logger.sendInfo("${message.author?.tag} の引用に成功しました: ID - ${targetMessage.id}")
+        Logger.sendInfo("${requester.username} のリクエストを承認しました。(引用メッセージID: ${replyMessage.id})")
 
     }
 
     /**
-     * メッセージタイプを確認する。
+     * 引用対象のメッセージを検索します。
+     *
+     * @param request 引用リクエストのメッセージ
+     * @return 引用対象のメッセージ
+     */
+    private suspend fun getQuoteMessage(request: Message, linkRegex: Regex, requester: Member): Message {
+
+        val requestGuild = request.getGuild()
+
+        val requesterDisplayName = Utils.createUserDisplayName(requester.username, requester.id, false)
+
+        if(requester.isBot) {
+            throw Error("Botのリクエストをブロックしました。<リクエスト送信者: $requesterDisplayName>")
+        }
+
+        // ID群の取り出し
+        val matches = linkRegex.find(request.content)
+            ?: throw Error("IDが不正のリクエストを拒否しました。<リクエスト送信者: $requesterDisplayName>")
+
+        if(Snowflake(matches.groupValues[1]) != requestGuild.id) {
+            throw Error("別ギルドのメッセージの引用リクエストを拒否しました。<リクエスト送信者: $requesterDisplayName>")
+        }
+
+        // チャンネルの検索、及び検査
+        val channel = requestGuild.getChannelOfOrNull<GuildMessageChannel>(Snowflake(matches.groupValues[2]))
+            ?: throw Error("チャンネルが見つかりませんでした。")
+
+        if(!(channel.data.nsfw.discordBoolean)) {
+            if(isChannelNsfw(channel)) {
+                throw Error("NSFWのメッセージ引用リクエストをブロックしました。<リクエスト送信者: $requesterDisplayName>")
+            }
+        }
+
+        // メッセージの取得
+        val message = channel.getMessageOrNull(Snowflake(matches.groupValues[3]))
+            ?: throw Error("メッセージが見つかりませんでした。")
+
+        if(!checkMessageType(message)) {
+            throw Error("メッセージステータスまたはタイプが不正です。<リクエスト送信者: $requesterDisplayName>")
+        }
+
+        return message
+    }
+
+    /**
+     * メッセージタイプと引用すべきメッセージなのかを確認する。
      *
      * @return citationが引用できるメッセージタイプであればTrue, なければFalse
      */
-    private fun checkMessageType(targetMessage: Message): Boolean {
-        if(targetMessage.type != MessageType.Default) {
-            if(targetMessage.type != MessageType.Reply) return true
-            if(targetMessage.type != MessageType.ThreadStarterMessage) return true
-
+    private fun checkMessageType(message: Message): Boolean {
+        if(message.embeds.isNotEmpty() && message.content.isEmpty()) {
             return false
         }
-        return true
+
+        return when(message.type) {
+            MessageType.Default, MessageType.Reply, MessageType.ThreadStarterMessage -> {
+                true
+            }
+
+            else -> {
+                false
+            }
+        }
     }
 
     /**
      * 引数て指定されたGuildMessageChannelがNSFWではないかの確認を行う。
-     * (同時に引用が行われたチャンネルも確認し、NSFWでなければFalseを戻す)
      *
+     * @param channel 検査対象のチャンネル
      * @return NSFWであればTrue, なければFalse
      */
-    private suspend fun isChannelNsfw(targetChannel: GuildMessageChannel, messageChannel: GuildMessageChannel): Boolean {
-        if(messageChannel.data.nsfw.discordBoolean) {
-            return false
-        }
-
-        if(targetChannel.type == ChannelType.PublicGuildThread || targetChannel.type == ChannelType.PrivateThread || targetChannel.type == ChannelType.PublicNewsThread) {
-            targetChannel as ThreadChannel
-            val parentChannel = targetChannel.getParent()
-            if(parentChannel.data.nsfw.discordBoolean) {
-                return true
-            }
-        }
-
-        if (targetChannel.data.nsfw.discordBoolean) {
+    private suspend fun isChannelNsfw(channel: GuildMessageChannel): Boolean {
+        if(channel.data.nsfw.discordBoolean) {
             return true
         }
 
-        return false
+        when(channel.type) {
+            ChannelType.PublicGuildThread, ChannelType.PrivateThread, ChannelType.PublicNewsThread -> {
+                channel as ThreadChannel
+                if(channel.getParent().data.nsfw.discordBoolean) {
+                    return true
+                }
+                return false
+            }
+            else -> {
+                return false
+            }
+        }
     }
 
 
     /**
      * 埋め込みを生成する
      *
+     * @param message 引用メッセージ
+     * @param requesterName リクエスト送信者の名前
      * @return 引用結果(Embed)を返す。
      */
-    private fun buildEmbed(targetMessage: Message, targetUserName: String, targetUserAvatar: Icon?, quoteOwner: User?): EmbedBuilder {
+    private suspend fun buildEmbed(message: Message, requesterName: String): EmbedBuilder {
+        val messageAuthor = message.author?.fetchMember(message.getGuild().id) ?: throw Error("埋め込みの生成に失敗しました。")
+
         val embed = EmbedBuilder().apply {
-            if(targetMessage.attachments.isNotEmpty()) {
-                targetMessage.attachments.forEach{ attachment -> image = attachment.url }
+            description = message.content
+            color = messageAuthor.accentColor
+            timestamp = message.timestamp
+            footer {
+                text = "リクエスト送信者: $requesterName"
             }
 
-            if(targetUserAvatar == null) {
-                author { name = targetUserName }
-            } else {
-                author { name = targetUserName; icon = targetUserAvatar.url }
-            }
-
-            if (quoteOwner != null) {
-                if(quoteOwner.avatar == null) {
-                    footer { text = quoteOwner.username; }
-                } else {
-                    footer { text = quoteOwner.username; icon = quoteOwner.avatar!!.url }
+            if(message.editedTimestamp !== null) {
+                field {
+                    name = "編集"
+                    value = message.editedTimestamp.toString()
                 }
             }
 
-            description = targetMessage.content
-            color = Color(160, 232, 210) // 薄緑色
-            timestamp = targetMessage.timestamp
+            if(messageAuthor.avatar !== null) {
+                author { name = messageAuthor.username; icon = messageAuthor.avatar?.url }
+            } else {
+                author { name = messageAuthor.username }
+            }
+
+            // 添付ファイルの確認
+            if(message.attachments.isNotEmpty()) {
+                message.attachments.forEach { attachment ->
+                    if(!(attachment.isImage)) return@forEach
+
+                    if(attachment.description !== null) {
+                        field {
+                            name = "ALTテキスト"
+                            value = attachment.description.toString()
+                            inline = true
+                        }
+                    }
+
+                    if(attachment.isSpoiler) {
+                        field {
+                            name = "スポイラー済みの添付ファイル"
+                            value = "[${attachment.filename}](${attachment.url})"
+                            inline = true
+                        }
+                        return@forEach
+                    }
+
+                    image = attachment.url
+                    field {
+                        name = "添付ファイル"
+                        value = attachment.filename
+                        inline = true
+                    }
+                }
+            }
         }
 
         return embed

--- a/src/main/kotlin/dev/m2en/citation/utils/Utils.kt
+++ b/src/main/kotlin/dev/m2en/citation/utils/Utils.kt
@@ -1,0 +1,22 @@
+package dev.m2en.citation.utils
+
+import dev.kord.common.entity.Snowflake
+
+class Utils {
+
+    companion object {
+        /**
+         * citation準拠のユーザー表示名を作成します。
+         * @param userName ユーザー名, メンションタイプを作成する際は使用されません。(デフォルト値: 空文字列)
+         * @param userId ユーザーID
+         * @param mentionType メンションタイプとして表示するかどうか (Embedで表示する際はこれを有効にしてください, デフォルト値: false)
+         */
+        fun createUserDisplayName(userName: String = "", userId: Snowflake, mentionType: Boolean = false): String {
+            return if(mentionType) {
+                "<@${userId}>"
+            } else {
+                "${userName}(${userId})"
+            }
+        }
+    }
+}


### PR DESCRIPTION
### 関連したIssue

close #62 

<!-- 
    このプルリクエストに関連したIssueの番号を入力します。(ここで入力された番号のIssueが関連するIssueとして扱われます。)
    ここで指定された関連Issueは、プルリクエストがマージされ閉じられた際に自動的に閉じられます。
    複数のIssueを指定する際は、close #1, close #2 のように記述してください。
    詳細: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

### 概要

Botのメッセージは無視するようにしました。

### 変更内容

Botのメッセージは引用せず無視するようにし、メッセージシステムのリファクタリングを行いました。

