### PR TITLE
fix: citationがリアクションを送信した際に無視しない問題の修正

### DIFF
--- a/src/main/kotlin/dev/m2en/citation/message/QuoteDelete.kt
+++ b/src/main/kotlin/dev/m2en/citation/message/QuoteDelete.kt
@@ -18,7 +18,7 @@ class QuoteDeleteListener(private val selfId: Snowflake, private val userId: Sno
         val targetMessage = message.fetchMessage() // 削除対象のメッセージ
         val targetMessageReference = targetMessage.messageReference ?: return
 
-        if(selfId == userId && targetMessage.author?.id != selfId) {
+        if(selfId == userId || targetMessage.author?.id != selfId) {
             return
         }
 

--- a/src/main/kotlin/dev/m2en/citation/message/QuoteSend.kt
+++ b/src/main/kotlin/dev/m2en/citation/message/QuoteSend.kt
@@ -17,7 +17,6 @@ object QuoteSendListener : MessageHandler {
     override suspend fun canProcess(message: Message): Boolean = message.author?.isBot == false
 
     override suspend fun messageHandle(message: Message) {
-        val requester = message.author?.fetchMember(message.getGuild().id) ?: throw Error("リクエスト送信者を見つけることができませんでした。")
 
         /**
          * メッセージリンクを取り出す正規表現
@@ -36,6 +35,8 @@ object QuoteSendListener : MessageHandler {
         if(!(linkRegex.containsMatchIn(content))) {
             return
         }
+
+        val requester = message.author?.fetchMember(message.getGuild().id) ?: throw Error("リクエスト送信者を見つけることができませんでした。")
 
         val quoteMessage = getQuoteMessage(message, linkRegex, requester)
 


### PR DESCRIPTION
### 変更内容

citationが 🗑️ をリアクションした際に評価してしまう問題を修正しました。